### PR TITLE
chore(docs): add v1.1.1 security upgrade

### DIFF
--- a/atomone-1/README.md
+++ b/atomone-1/README.md
@@ -2,7 +2,11 @@
 
 ![chain-id](https://img.shields.io/badge/chain%20id-atomone--1-blue?style=for-the-badge)
 ![version: v1.1.1](https://img.shields.io/badge/version-v1.1.1-green?style=for-the-badge)
-![genesis.json](https://atomone.fra1.digitaloceanspaces.com/genesis.json)
+
+## Versions
+
+- [Security upgrade v1.1.1](./v1.1.1.md) - [v1.1.1](https://github.com/atomone-hub/atomone/releases/tag/v1.1.1) (current)
+- [Genesis](./genesis.md) - [v1.0.0](https://github.com/atomone-hub/atomone/releases/tag/v1.0.0)
 
 ## Operate the node
 
@@ -22,6 +26,13 @@ $ cd atomone
 $ git checkout v1.1.1
 $ make install
 ```
+
+### Setup [genesis.json](https://atomone.fra1.digitaloceanspaces.com/genesis.json)
+
+```bash
+$ wget -O $HOME/.atomone/config/genesis.json https://atomone.fra1.digitaloceanspaces.com/genesis.json
+```
+
 
 ### Recommendations
 

--- a/atomone-1/v1.1.1.md
+++ b/atomone-1/v1.1.1.md
@@ -1,0 +1,18 @@
+# v1.1.1
+
+- https://github.com/atomone-hub/atomone/releases/tag/v1.1.1
+- https://github.com/atomone-hub/atomone/releases/tag/v1.1.0
+
+the upgrade bumps the ibc-go dependency to address ASA-2025-004 (https://github.com/cosmos/ibc-go/security/advisories/GHSA-jg6f-48ff-5xrw, https://github.com/cosmos/ibc-go/releases/tag/v7.9.0).
+
+This is a state-machine-breaking update which means that a 2/3 of the voting power is required to be on this version for the chain to not be vulnerable.
+
+However, due to the nature of the update (a vulnerability fix) we had to roll out this as an emergency upgrade instead of a on-chain voted chain upgrade.
+
+As also concluded in the vulnerability disclosure, in principle the update can happen on a rolling basis, meaning validators can update as soon as they see this message and there is no practical need for a coordinated upgrade. Therefore, contrary to what planned there will be no coordinated upgrade but validators can instead start upgrading immediately.
+
+However, it is important to note that if the chain is attacked by exploiting the vulnerability in the meantime, the only way to unfreeze the halt will be for 2/3 of the voting power to have upgraded.
+
+---
+
+Due to issues related to existing modules like - the packet-forwarding-middleware - that is present on the Cosmos Hub, the Ibc-Go team had to release another update v7.9.2 (https://github.com/cosmos/ibc-go/releases/tag/v7.9.2 ) while they retracted the v7.9.0 release that was included in v1.1.0 release of  atomoned. 


### PR DESCRIPTION
Now that network is safely upgraded, we could add the informations about v1.1.1 upgrade