### PR TITLE
chore: atomone-1 upgrade v4.0.0

### DIFF
--- a/atomone-1/upgrades/v4.0.0.md
+++ b/atomone-1/upgrades/v4.0.0.md
@@ -4,8 +4,8 @@
 
 - **Version**: [v4.0.0](https://github.com/atomone-hub/atomone/releases/tag/v4.0.0)
 - **Version name (for cosmovisor)**: `v4`
-- **Upgrade Height**: [Block <HEIGHT>](https://www.mintscan.io/atomone/block/<HEIGHT>)
-- **Governance Proposal**: [Proposal #<N>](https://www.mintscan.io/atomone/proposals/<N>)
+- **Upgrade Height**: [Block 9550000](https://www.mintscan.io/atomone/block/9550000)
+- **Governance Proposal**: [Proposal #21](https://www.mintscan.io/atomone/proposals/21)
 
 > [!IMPORTANT]
 > This release upgrades AtomOne to Cosmos SDK v0.50 and IBC v10. It also

--- a/atomone-1/upgrades/v4.0.0.md
+++ b/atomone-1/upgrades/v4.0.0.md
@@ -1,0 +1,39 @@
+# [v4.0.0](https://github.com/atomone-hub/atomone/releases/tag/v4.0.0)
+
+## Upgrade Information
+
+- **Version**: [v4.0.0](https://github.com/atomone-hub/atomone/releases/tag/v4.0.0)
+- **Version name (for cosmovisor)**: `v4`
+- **Upgrade Height**: [Block <HEIGHT>](https://www.mintscan.io/atomone/block/<HEIGHT>)
+- **Governance Proposal**: [Proposal #<N>](https://www.mintscan.io/atomone/proposals/<N>)
+
+> [!IMPORTANT]
+> This release upgrades AtomOne to Cosmos SDK v0.50 and IBC v10. It also
+> introduces the `x/coredaos` module and migrates internal governance state to
+> use the Cosmos SDK gov keeper. The proto paths for `atomone.gov.v1` are
+> preserved through the `x/gov` wrapper module, maintaining compatibility for
+> external clients.
+>
+> Building `v4.0.0` requires **Go 1.26.4**.
+
+More informations present in [UPGRADING.md](https://github.com/atomone-hub/atomone/blob/v4.0.0/UPGRADING.md)
+
+```sh
+cd atomone
+git fetch --tags && git checkout v4.0.0
+
+make build && make install
+
+atomoned version --long | grep "cosmos_sdk_version\|commit\|version:"
+# commit: 2516c492846e0cc6637c9e6077e2bbc0803f0509
+# cosmos_sdk_version: v0.500.1
+# version: v4.0.0
+```
+
+### Using cosmovisor
+
+```sh
+mkdir -p $DAEMON_HOME/cosmovisor/upgrades/v4/bin && cp $HOME/go/bin/atomoned $DAEMON_HOME/cosmovisor/upgrades/v4/bin
+
+$DAEMON_HOME/cosmovisor/upgrades/v4/bin/atomoned version
+```


### PR DESCRIPTION
## Summary

Adds the `atomone-1` (mainnet) upgrade instructions for **v4.0.0**, mirroring the existing mainnet upgrade docs (e.g. `v3.0.3.md`).

Values sourced from the [v4.0.0 release](https://github.com/atomone-hub/atomone/releases/tag/v4.0.0):
- Cosmovisor name: `v4`
- commit: `2516c492846e0cc6637c9e6077e2bbc0803f0509`
- cosmos_sdk_version: `v0.500.1`
- Upgrade Height: **9550000**
- Governance Proposal: [#21](https://www.mintscan.io/atomone/proposals/21)
- Note: upgrades to Cosmos SDK v0.50 & IBC v10, introduces `x/coredaos`, migrates gov state to the SDK gov keeper; requires **Go 1.26.4** to build.
