### PR TITLE
docs(atomone-1): recommend v4.0.1 as current v4 binary

### DIFF
--- a/atomone-1/README.md
+++ b/atomone-1/README.md
@@ -1,11 +1,12 @@
 # 🔗 `atomone-1`
 
 ![chain-id](https://img.shields.io/badge/chain%20id-atomone--1-blue?style=for-the-badge)
-![version: v3.0.3](https://img.shields.io/badge/version-v3.0.3-green?style=for-the-badge)
+![version: v4.0.1](https://img.shields.io/badge/version-v4.0.1-green?style=for-the-badge)
 
 ## Versions
 
-- [v3.0.3](./upgrades/v3.0.3.md) - [v3.0.3](https://github.com/atomone-hub/atomone/releases/tag/v3.0.3) (current)
+- [v4.0.0](./upgrades/v4.0.0.md) - [v4.0.1](https://github.com/atomone-hub/atomone/releases/tag/v4.0.1) (current)
+- [v3.0.3](./upgrades/v3.0.3.md) - [v3.0.3](https://github.com/atomone-hub/atomone/releases/tag/v3.0.3)
 - [v2.0.0](./upgrades/v2.0.0.md) - [v2.0.0](https://github.com/atomone-hub/atomone/releases/tag/v2.0.0)
 - [Security upgrade v1.1.2](./upgrades/v1.1.2.md) - [v1.1.2](https://github.com/atomone-hub/atomone/releases/tag/v1.1.2)
 - [Security upgrade v1.1.1](./upgrades/v1.1.1.md) - [v1.1.1](https://github.com/atomone-hub/atomone/releases/tag/v1.1.1)
@@ -17,7 +18,7 @@
 
 - You can install the proposed chain binary from github release page
 
-https://github.com/atomone-hub/atomone/releases/tag/v3.0.3
+https://github.com/atomone-hub/atomone/releases/tag/v4.0.1
 
 - Build from the source
 
@@ -26,7 +27,7 @@ You need to have [go](https://go.dev/doc/install) installed
 ```sh
 $ git clone https://github.com/atomone-hub/atomone.git
 $ cd atomone
-$ git checkout v3.0.3
+$ git checkout v4.0.1
 $ make install
 ```
 

--- a/atomone-1/upgrades/v4.0.0.md
+++ b/atomone-1/upgrades/v4.0.0.md
@@ -2,32 +2,38 @@
 
 ## Upgrade Information
 
-- **Version**: [v4.0.0](https://github.com/atomone-hub/atomone/releases/tag/v4.0.0)
+- **Version**: [v4.0.1](https://github.com/atomone-hub/atomone/releases/tag/v4.0.1) (current)
 - **Version name (for cosmovisor)**: `v4`
 - **Upgrade Height**: [Block 9550000](https://www.mintscan.io/atomone/block/9550000)
 - **Governance Proposal**: [Proposal #21](https://www.mintscan.io/atomone/proposals/21)
 
 > [!IMPORTANT]
+> The upgrade at block 9550000 was executed with `v4.0.0`. **`v4.0.1` is now the
+> current release and the binary you should run.** It is a state-machine
+> compatible patch over `v4.0.0` that registers the legacy IBC gov proposal
+> content types in the AtomOne gov fork
+> ([#356](https://github.com/atomone-hub/atomone/pull/356)).
+>
 > This release upgrades AtomOne to Cosmos SDK v0.50 and IBC v10. It also
 > introduces the `x/coredaos` module and migrates internal governance state to
 > use the Cosmos SDK gov keeper. The proto paths for `atomone.gov.v1` are
 > preserved through the `x/gov` wrapper module, maintaining compatibility for
 > external clients.
 >
-> Building `v4.0.0` requires **Go 1.26.4**.
+> Building `v4.0.1` requires **Go 1.26.4**.
 
-More informations present in [UPGRADING.md](https://github.com/atomone-hub/atomone/blob/v4.0.0/UPGRADING.md)
+More informations present in [UPGRADING.md](https://github.com/atomone-hub/atomone/blob/v4.0.1/UPGRADING.md)
 
 ```sh
 cd atomone
-git fetch --tags && git checkout v4.0.0
+git fetch --tags && git checkout v4.0.1
 
 make build && make install
 
 atomoned version --long | grep "cosmos_sdk_version\|commit\|version:"
-# commit: 2516c492846e0cc6637c9e6077e2bbc0803f0509
+# commit: 85862ff1b541267e24798880d6b48b4d45962083
 # cosmos_sdk_version: v0.500.1
-# version: v4.0.0
+# version: v4.0.1
 ```
 
 ### Using cosmovisor


### PR DESCRIPTION
## Summary
Updates the atomone-1 v4 upgrade doc to point operators at **v4.0.1** as the current binary to run.

- **Version** line now shows [`v4.0.1`](https://github.com/atomone-hub/atomone/releases/tag/v4.0.1), tagged as *current — recommended binary*
- Notes that the on-chain upgrade at block 9550000 ran with `v4.0.0`, and that `v4.0.1` is a **state-machine compatible patch** — registers legacy IBC gov proposal content types in the AtomOne gov fork ([#356](https://github.com/atomone-hub/atomone/pull/356))
- Build/checkout commands, `version --long` sample output (commit `85862ff…`), Go note, and UPGRADING.md link updated to `v4.0.1`

Filename/heading and cosmovisor dir stay `v4` (governance-approved upgrade name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)